### PR TITLE
Fix tangent projection

### DIFF
--- a/s2sphere/sphere.py
+++ b/s2sphere/sphere.py
@@ -1481,7 +1481,7 @@ class CellId(object):
         if cls.PROJECTION == cls.LINEAR_PROJECTION:
             return 0.5 * (u + 1)
         elif cls.PROJECTION == cls.TAN_PROJECTION:
-            return (2 * (1.0 / math.pi)) * (math.atan(u) * math.pi / 4.0)
+            return (2 * (1.0 / math.pi)) * (math.atan(u) + math.pi / 4.0)
         elif cls.PROJECTION == cls.QUADRATIC_PROJECTION:
             if u >= 0:
                 return 0.5 * math.sqrt(1 + 3 * u)


### PR DESCRIPTION
I think there's a typo in the helper function `CellId.uv_to_st` in the case that `CellId.PROJECTION == 1` (the tangent projection). To wit: this should be an increasing function that maps `[-1, 1]` to `[0, 1]`, and in the default case it does. For example:
```
>>> import s2sphere
>>> s2sphere.CellId.uv_to_st(-1)
0.0
>>> s2sphere.CellId.uv_to_st(1)
1.0
>>>
```
However, if we use the tangent projection, this isn't the case:
```
>>> s2sphere.CellId.PROJECTION = 1
>>> s2sphere.CellId.uv_to_st(-1)
-0.39269908169872414
>>>
```
I think this PR resolves the issue. Indeed, this function now matches the analogous function in the original C++ library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/s2sphere/34)
<!-- Reviewable:end -->
